### PR TITLE
Remove hard-coded home directory from Make.rules

### DIFF
--- a/examples/Make.rules
+++ b/examples/Make.rules
@@ -1,6 +1,6 @@
 
 ARCH=riscv32-unknown-elf
-GNU_DIR=/home/winans/projects/riscv/install/rv32i
+GNU_DIR=$(HOME)/projects/riscv/install/rv32i
 GNU_BIN=$(GNU_DIR)/bin
 
 


### PR DESCRIPTION
Make.rules has a hard-coded path to /home/winans