### PR TITLE
Using nullptr in order to fix NULL error for c++11

### DIFF
--- a/src/devices.h
+++ b/src/devices.h
@@ -55,7 +55,7 @@ public:
 
 	static void errorGet(const char *len, uint64_t addr);
 	static void errorSet(const char *len, uint64_t addr, uint64_t val);
-	static void errorInvalidWrite(const char *len, uint64_t addr, uint64_t val, const char *msg=NULL);
+	static void errorInvalidWrite(const char *len, uint64_t addr, uint64_t val, const char *msg=nullptr);
 
 private:
 	int warnings;


### PR DESCRIPTION
Nothing special, just no more compilation error.